### PR TITLE
bitbake.sh: add the full path for the setuser command and also add sudo

### DIFF
--- a/bitbake.sh
+++ b/bitbake.sh
@@ -2,5 +2,5 @@
 
 cmd=$(basename $0)
 
-setuser builduser \
+sudo -E /sbin/setuser builduser \
 	bash -c "source /var/build/poky/oe-init-build-env && export BB_ENV_EXTRAWHITE=\"${BB_ENV_EXTRAWHITE} MACHINE SSTATE_DIR SSTATE_MIRRORS SSH_AUTH_SOCK\" && ${cmd} $*"


### PR DESCRIPTION
When trying to run an interactive command set as the builduser, the bitbake command can fail without the sudo.  

The reason to add this is to more easily run the do_\* commands in an interactive shell without worrying about the build items being owned by root and getting a do_clean failure

Signed-off-by: Derek Straka derek@asterius.io
